### PR TITLE
 expose stir-method set_recompute_mask_image to cSTIR

### DIFF
--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -910,6 +910,10 @@ The actual algorithm is described in
         {
             stir::ScatterEstimation::set_mask_proj_data_sptr(arg->data());
         }
+		void set_recompute_mask_image(bool arg)
+        {
+            stir::ScatterEstimation::set_recompute_mask_image(arg);
+        }
 
         //! Set prefix for filenames with scatter estimates.
         /*!

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -910,10 +910,12 @@ The actual algorithm is described in
         {
             stir::ScatterEstimation::set_mask_proj_data_sptr(arg->data());
         }
-		void set_recompute_mask_image(bool arg)
+#if STIR_VERSION >= 060200
+        void set_recompute_mask_image(bool arg)
         {
             stir::ScatterEstimation::set_recompute_mask_image(arg);
         }
+#endif
 
         //! Set prefix for filenames with scatter estimates.
         /*!


### PR DESCRIPTION
I got the following error when I tried to build from this branch, with STIR-master:
![image](https://github.com/user-attachments/assets/2ed2cd70-7eb3-4bb1-8220-646bcf5a8d2f)

I think the problem is that "set_recompute_mask_image" of the stir::ScatterEstimation is not exposed to the sirf::PETScatterEstimator in src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h, as the other newly accessed methods are here:

https://github.com/KrisThielemans/SIRF/blob/51911cc3695f8c9826972e6656fd13b01b5cfaec/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h#L905C1-L912C10

I think I managed to fix it with this PR. SIRF builds on my system now.